### PR TITLE
add xml file

### DIFF
--- a/lib.xml
+++ b/lib.xml
@@ -1,4 +1,4 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 ..\FrameXML\UI.xsd">
-	<Script file="LibSerialize.lua" />
+  <Script file="LibSerialize.lua" />
 </Ui>

--- a/lib.xml
+++ b/lib.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="LibSerialize.lua" />
+</Ui>


### PR DESCRIPTION
In case in the future, you ever decide to split the code into multiple files. This way, consumers can just add a single file into their table of contents, and not have to care about the internal structure of the library.