### PR TITLE
Generic Reader Support

### DIFF
--- a/LibSerialize.lua
+++ b/LibSerialize.lua
@@ -429,6 +429,35 @@ local function GetRequiredBytesNumber(value)
     return 7
 end
 
+-- Queries a given object for the value assigned to a specific key.
+--
+-- If the given object cannot be indexed, an error may be raised by the Lua
+-- implementation.
+local function GetValueByKey(object, key)
+    return object[key]
+end
+
+-- Queries a given object for the value assigned to a specific key, returning
+-- it if non-nil or giving back a default.
+--
+-- If the given object cannot be indexed, the default will be returned and
+-- no error raised.
+local function GetValueByKeyOrDefault(object, key, default)
+    local ok, value = pcall(GetValueByKey, object, key)
+
+    if not ok or value == nil then
+        return default
+    else
+        return value
+    end
+end
+
+-- Implements the default end-of-stream check for a reader. This requires
+-- that the supplied input object supports the length operator.
+local function HasReachedInputEnd(input, offset)
+    return offset > #input
+end
+
 -- Returns whether the value (a number) is NaN.
 local function IsNaN(value)
     -- With floating point optimizations enabled all comparisons involving
@@ -526,35 +555,6 @@ local function CreateWriter()
     end
 
     return WriteString, FlushWriter
-end
-
--- Queries a given object for the value assigned to a specific key.
---
--- If the given object cannot be indexed, an error may be raised by the Lua
--- implementation.
-local function GetValueByKey(object, key)
-    return object[key]
-end
-
--- Queries a given object for the value assigned to a specific key, returning
--- it if non-nil or giving back a default.
---
--- If the given object cannot be indexed, the default will be returned and
--- no error raised.
-local function GetValueByKeyOrDefault(object, key, default)
-    local ok, value = pcall(GetValueByKey, object, key)
-
-    if not ok or value == nil then
-        return default
-    else
-        return value
-    end
-end
-
--- Implements the default end-of-stream check for a reader. This requires
--- that the supplied input object supports the length operator.
-local function HasReachedInputEnd(input, offset)
-    return offset > #input
 end
 
 -- Creates a reader to sequentially read bytes from the input string.

--- a/LibSerialize.lua
+++ b/LibSerialize.lua
@@ -153,7 +153,7 @@ end
 This will occur if any of the following exceed 16777215: any string length,
 any table key count, number of unique strings, number of unique tables.
 It will also occur by default if any unserializable types are encountered,
-though that behavior may be disabled (see "Serialization Options").
+though that behavior may be disabled (see [Serialization Options]).
 
 `Deserialize()` and `DeserializeValue()` are equivalent, except the latter
 returns the deserialization result directly and will not catch any Lua

--- a/LibSerialize.lua
+++ b/LibSerialize.lua
@@ -211,8 +211,8 @@ will override default behaviors otherwise implemented by the library.
     to read a sequence of bytes as a string from the supplied input. The range
     of bytes is passed in the `i` and `j` parameters, with similar semantics
     to standard Lua functions such as `string.sub` and `table.concat`. This
-    function must return a string whose length is at-least equal to the
-    requested range of bytes.
+    function must return a string whose length is equal to the requested range
+    of bytes.
 
     It is permitted for this function to error if the range of bytes would
     exceed the available bytes; if an error is raised it will pass through

--- a/LibSerialize.lua
+++ b/LibSerialize.lua
@@ -104,7 +104,7 @@ end
 * **`LibSerialize:SerializeEx(opts, ...)`**
 
     Arguments:
-    * `opts`: options (see "Serialization Options")
+    * `opts`: options (see [Serialization Options])
     * `...`: a variable number of serializable values
 
     Returns:
@@ -118,23 +118,21 @@ end
     Returns:
     * `result`: `...` serialized as a string
 
-    Calls `SerializeEx(opts, ...)` with the default serialization options (see "Serialization Options")
+    Calls `SerializeEx(opts, ...)` with the default serialization options (see [Serialization Options])
 
-* **`LibSerialize:Deserialize(input[, options])`**
+* **`LibSerialize:Deserialize(input)`**
 
     Arguments:
-    * `input`: a string previously returned from `LibSerialize:Serialize()`
-    * `options`: an optional table of options to control deserialization (see "Deserialization Options")
+    * `input`: a string previously returned from `LibSerialize:Serialize()`, or an object that implements the [Reader protocol]
 
     Returns:
     * `success`: a boolean indicating if deserialization was successful
     * `...`: the deserialized value(s), or a string containing the encountered Lua error
 
-* **`LibSerialize:DeserializeValue(input[, options])`**
+* **`LibSerialize:DeserializeValue(input)`**
 
     Arguments:
-    * `input`: a string previously returned from `LibSerialize:Serialize()`
-    * `options`: an optional table of options to control deserialization (see "Deserialization Options")
+    * `input`: a string previously returned from `LibSerialize:Serialize()`, or an object that implements the [Reader protocol]
 
     Returns:
     * `...`: the deserialized value(s)
@@ -161,45 +159,18 @@ though that behavior may be disabled (see "Serialization Options").
 returns the deserialization result directly and will not catch any Lua
 errors that may occur when deserializing invalid input.
 
-Note that none of the serialization/deserialization methods support reentrancy,
-and modifying tables during the serialization process is unspecified and
-should be avoided. Table serialization is multi-phased and assumes a consistent
-state for the key/value pairs across the phases.
+As of recent releases, the library supports reentrancy and concurrent usage
+from multiple threads (coroutines) through the public API. Modifying tables
+during the serialization process is unspecified and should be avoided.
+Table serialization is multi-phased and assumes a consistent state for the
+key/value pairs across the phases.
 
-## Deserialization Options:
-The following deserialization options are supported:
-* `readBytes`: `function(input, i, j) => string` (optional)
-  * If specified, this function will be called every time the library needs
-    to read a sequence of bytes as a string from the supplied input. The range
-    of bytes is passed in the `i` and `j` parameters, with similar semantics
-    to standard Lua functions such as `string.sub` and `table.concat`. This
-    function must return a string whose length is at-least equal to the
-    requested range of bytes.
+It is permitted for any user-supplied functions to suspend the current
+thread during the serialization or deserialization process. It is however
+not possible to yield the current thread if the `Deserialize()` API is used,
+as this function inserts a C call boundary onto the call stack. This issue
+does not affect the `DeserializeValue()` function.
 
-    It is permitted for this function to error if the range of bytes would
-    exceed the available bytes; if an error is raised it will pass through
-    the library back to the caller of Deserialize/DeserializeValue.
-
-    If not supplied, the default implementation will access the contents of
-    `input` as if it were a string and call `string.sub(input, i, j)`.
-* `atEnd`: `function(input, i)` (optional)
-  * If specified, this function will be called whenever the library needs to
-    test if the end of the input has been reached. The `i` parameter will be
-    supplied a byte offset from the start of the input, and should typically
-    return `true` if `i` is greater than the length of `input`.
-
-    If this function returns true, the stream is considered ended and further
-    values will not be deserialized. If this function returns false,
-    deserialization of further values will continue until it returns true.
-
-    If not supplied, the default implementation will compare the offset `i`
-    against the length of `input` as obtained through the `#` operator.
-
-Implementations for custom functions are permitted to yield the current
-thread if deserialization is being processed within a coroutine, however this
-is only possible if the `DeserializeValue()` function was used and not
-`Deserialize()`. This is because the latter function inserts a C call
-boundary onto the call stack, preventing yields from being possible.
 
 ## Serialization Options:
 The following serialization options are supported:
@@ -224,6 +195,44 @@ This means that if an option `foo` defaults to true, then:
 * `myOpts.foo = false`: option `foo` is false
 * `myOpts.foo = nil`: option `foo` is true
 
+## Reader Protocol
+The library supports customizing how serialized data is provided to the
+deserialization functions through the use of the "Reader" protocol. This
+enables advanced use cases such as batched or throttled deserialization via
+coroutines, or processing serialized data of an unknown-length in a streamed
+manner.
+
+Any value supplied as the `input` to any deserialization function will be
+inspected and indexed to search for the following keys. If provided, these
+will override default behaviors otherwise implemented by the library.
+
+* `ReadBytes`: `function(input, i, j) => string` (optional)
+  * If specified, this function will be called every time the library needs
+    to read a sequence of bytes as a string from the supplied input. The range
+    of bytes is passed in the `i` and `j` parameters, with similar semantics
+    to standard Lua functions such as `string.sub` and `table.concat`. This
+    function must return a string whose length is at-least equal to the
+    requested range of bytes.
+
+    It is permitted for this function to error if the range of bytes would
+    exceed the available bytes; if an error is raised it will pass through
+    the library back to the caller of Deserialize/DeserializeValue.
+
+    If not supplied, the default implementation will access the contents of
+    `input` as if it were a string and call `string.sub(input, i, j)`.
+
+* `AtEnd`: `function(input, i) => boolean` (optional)
+  * If specified, this function will be called whenever the library needs to
+    test if the end of the input has been reached. The `i` parameter will be
+    supplied a byte offset from the start of the input, and should typically
+    return `true` if `i` is greater than the length of `input`.
+
+    If this function returns true, the stream is considered ended and further
+    values will not be deserialized. If this function returns false,
+    deserialization of further values will continue until it returns true.
+
+    If not supplied, the default implementation will compare the offset `i`
+    against the length of `input` as obtained through the `#` operator.
 
 ## Customizing table serialization:
 For any serialized table, LibSerialize will check for the presence of a
@@ -519,6 +528,31 @@ local function CreateWriter()
     return WriteString, FlushWriter
 end
 
+-- Queries a given object for the value assigned to a specific key.
+--
+-- If the given object cannot be indexed, an error may be raised by the Lua
+-- implementation.
+local function GetValueByKey(object, key)
+    return object[key]
+end
+
+-- Queries a given object for the value assigned to a specific key, returning
+-- it if non-nil or giving back a default.
+--
+-- If the given object cannot be indexed, the default will be returned and
+-- no error raised.
+local function GetValueByKeyOrDefault(object, key, default)
+    local ok, value = pcall(GetValueByKey, object, key)
+
+    if not ok or value == nil then
+        return default
+    else
+        return value
+    end
+end
+
+-- Implements the default end-of-stream check for a reader. This requires
+-- that the supplied input object supports the length operator.
 local function HasReachedInputEnd(input, offset)
     return offset > #input
 end
@@ -527,16 +561,16 @@ end
 -- Return values:
 -- 1. ReadBytes(bytelen)
 -- 2. ReaderAtEnd()
-local function CreateReader(input, options)
+local function CreateReader(input)
     local nextPos = 1
 
-    local readBytes = string_sub
-    local atEnd = HasReachedInputEnd
+    -- We delegate to duck typing here and allow any type of input to just be
+    -- given and queried for the custom reader interface; any errors that
+    -- arise when attempting to index these fields are swallowed and it'll
+    -- just be assumed that the input doesn't walk like a duck.
 
-    if type(options) == "table" then
-        readBytes = options.readBytes or readBytes
-        atEnd = options.atEnd or atEnd
-    end
+    local readBytes = GetValueByKeyOrDefault(input, "ReadBytes", string_sub)
+    local atEnd = GetValueByKeyOrDefault(input, "AtEnd", HasReachedInputEnd)
 
     -- Read some bytes from the reader.
     -- @param bytelen The number of bytes to be read.
@@ -707,7 +741,7 @@ local function CreateSerializer(opts)
     return state
 end
 
-local function CreateDeserializer(input, options)
+local function CreateDeserializer(input)
     local state = {}
 
     -- Copy the state from LibSerializeInt.
@@ -720,7 +754,7 @@ local function CreateDeserializer(input, options)
     state._tableRefs = {}
 
     -- Create the reader functions.
-    state._readBytes, state._readerAtEnd = CreateReader(input, options)
+    state._readBytes, state._readerAtEnd = CreateReader(input)
 
     return state
 end
@@ -1379,8 +1413,8 @@ function LibSerialize:Serialize(...)
     return self:SerializeEx(defaultOptions, ...)
 end
 
-function LibSerialize:DeserializeValue(input, options)
-    local deser = CreateDeserializer(input, options)
+function LibSerialize:DeserializeValue(input)
+    local deser = CreateDeserializer(input)
 
     -- Since there's only one compression version currently,
     -- no extra work needs to be done to decode the data.
@@ -1401,8 +1435,8 @@ function LibSerialize:DeserializeValue(input, options)
     return unpack(output, 1, outputSize)
 end
 
-function LibSerialize:Deserialize(input, options)
-    return pcall(self.DeserializeValue, self, input, options)
+function LibSerialize:Deserialize(input)
+    return pcall(self.DeserializeValue, self, input)
 end
 
 return LibSerialize

--- a/LibSerialize.lua
+++ b/LibSerialize.lua
@@ -179,6 +179,9 @@ The following deserialization options are supported:
     It is permitted for this function to error if the range of bytes would
     exceed the available bytes; if an error is raised it will pass through
     the library back to the caller of Deserialize/DeserializeValue.
+
+    If not supplied, the default implementation will access the contents of
+    `input` as if it were a string and call `string.sub(input, i, j)`.
 * `atEnd`: `function(input, i)` (optional)
   * If specified, this function will be called whenever the library needs to
     test if the end of the input has been reached. The `i` parameter will be
@@ -188,6 +191,9 @@ The following deserialization options are supported:
     If this function returns true, the stream is considered ended and further
     values will not be deserialized. If this function returns false,
     deserialization of further values will continue until it returns true.
+
+    If not supplied, the default implementation will compare the offset `i`
+    against the length of `input` as obtained through the `#` operator.
 
 Implementations for custom functions are permitted to yield the current
 thread if deserialization is being processed within a coroutine, however this

--- a/README.md
+++ b/README.md
@@ -84,21 +84,19 @@ end
 
     Calls `SerializeEx(opts, ...)` with the default serialization options (see [Serialization Options])
 
-* **`LibSerialize:Deserialize(input[, options])`**
+* **`LibSerialize:Deserialize(input)`**
 
     Arguments:
-    * `input`: a string previously returned from `LibSerialize:Serialize()`
-    * `options`: an optional table of options to control deserialization (see [Deserialization Options])
+    * `input`: a string previously returned from `LibSerialize:Serialize()`, or an object that implements the [Reader protocol]
 
     Returns:
     * `success`: a boolean indicating if deserialization was successful
     * `...`: the deserialized value(s), or a string containing the encountered Lua error
 
-* **`LibSerialize:DeserializeValue(input[, options])`**
+* **`LibSerialize:DeserializeValue(input)`**
 
     Arguments:
-    * `input`: a string previously returned from `LibSerialize:Serialize()`
-    * `options`: an optional table of options to control deserialization (see [Deserialization Options])
+    * `input`: a string previously returned from `LibSerialize:Serialize()`, or an object that implements the [Reader protocol]
 
     Returns:
     * `...`: the deserialized value(s)
@@ -119,51 +117,23 @@ end
 This will occur if any of the following exceed 16777215: any string length,
 any table key count, number of unique strings, number of unique tables.
 It will also occur by default if any unserializable types are encountered,
-though that behavior may be disabled (see [Serialization Options]).
+though that behavior may be disabled (see "Serialization Options").
 
 `Deserialize()` and `DeserializeValue()` are equivalent, except the latter
 returns the deserialization result directly and will not catch any Lua
 errors that may occur when deserializing invalid input.
 
-Note that none of the serialization/deserialization methods support reentrancy,
-and modifying tables during the serialization process is unspecified and
-should be avoided. Table serialization is multi-phased and assumes a consistent
-state for the key/value pairs across the phases.
+As of recent releases, the library supports reentrancy and concurrent usage
+from multiple threads (coroutines) through the public API. Modifying tables
+during the serialization process is unspecified and should be avoided.
+Table serialization is multi-phased and assumes a consistent state for the
+key/value pairs across the phases.
 
-## Deserialization Options:
-The following deserialization options are supported:
-* `readBytes`: `function(input, i, j) => string` (optional)
-  * If specified, this function will be called every time the library needs
-    to read a sequence of bytes as a string from the supplied input. The range
-    of bytes is passed in the `i` and `j` parameters, with similar semantics
-    to standard Lua functions such as `string.sub` and `table.concat`. This
-    function must return a string whose length is at-least equal to the
-    requested range of bytes.
-
-    It is permitted for this function to error if the range of bytes would
-    exceed the available bytes; if an error is raised it will pass through
-    the library back to the caller of Deserialize/DeserializeValue.
-
-    If not supplied, the default implementation will access the contents of
-    `input` as if it were a string and call `string.sub(input, i, j)`.
-* `atEnd`: `function(input, i)` (optional)
-  * If specified, this function will be called whenever the library needs to
-    test if the end of the input has been reached. The `i` parameter will be
-    supplied a byte offset from the start of the input, and should typically
-    return `true` if `i` is greater than the length of `input`.
-
-    If this function returns true, the stream is considered ended and further
-    values will not be deserialized. If this function returns false,
-    deserialization of further values will continue until it returns true.
-
-    If not supplied, the default implementation will compare the offset `i`
-    against the length of `input` as obtained through the `#` operator.
-
-Implementations for custom functions are permitted to yield the current
-thread if deserialization is being processed within a coroutine, however this
-is only possible if the `DeserializeValue()` function was used and not
-`Deserialize()`. This is because the latter function inserts a C call
-boundary onto the call stack, preventing yields from being possible.
+It is permitted for any user-supplied functions to suspend the current
+thread during the serialization or deserialization process. It is however
+not possible to yield the current thread if the `Deserialize()` API is used,
+as this function inserts a C call boundary onto the call stack. This issue
+does not affect the `DeserializeValue()` function.
 
 ## Serialization Options:
 The following serialization options are supported:
@@ -188,6 +158,44 @@ This means that if an option `foo` defaults to true, then:
 * `myOpts.foo = false`: option `foo` is false
 * `myOpts.foo = nil`: option `foo` is true
 
+## Reader Protocol
+The library supports customizing how serialized data is provided to the
+deserialization functions through the use of the "Reader" protocol. This
+enables advanced use cases such as batched or throttled deserialization via
+coroutines, or processing serialized data of an unknown-length in a streamed
+manner.
+
+Any value supplied as the `input` to any deserialization function will be
+inspected and indexed to search for the following keys. If provided, these
+will override default behaviors otherwise implemented by the library.
+
+* `ReadBytes`: `function(input, i, j) => string` (optional)
+  * If specified, this function will be called every time the library needs
+    to read a sequence of bytes as a string from the supplied input. The range
+    of bytes is passed in the `i` and `j` parameters, with similar semantics
+    to standard Lua functions such as `string.sub` and `table.concat`. This
+    function must return a string whose length is at-least equal to the
+    requested range of bytes.
+
+    It is permitted for this function to error if the range of bytes would
+    exceed the available bytes; if an error is raised it will pass through
+    the library back to the caller of Deserialize/DeserializeValue.
+
+    If not supplied, the default implementation will access the contents of
+    `input` as if it were a string and call `string.sub(input, i, j)`.
+
+* `AtEnd`: `function(input, i) => boolean` (optional)
+  * If specified, this function will be called whenever the library needs to
+    test if the end of the input has been reached. The `i` parameter will be
+    supplied a byte offset from the start of the input, and should typically
+    return `true` if `i` is greater than the length of `input`.
+
+    If this function returns true, the stream is considered ended and further
+    values will not be deserialized. If this function returns false,
+    deserialization of further values will continue until it returns true.
+
+    If not supplied, the default implementation will compare the offset `i`
+    against the length of `input` as obtained through the `#` operator.
 
 ## Customizing table serialization:
 For any serialized table, LibSerialize will check for the presence of a
@@ -308,4 +316,4 @@ The type byte uses the following formats to implement the above:
     * Followed by the type-dependent payload, including count(s) if needed
 
 [Serialization Options]: #serialization-options
-[Deserialization Options]: #deserialization-options
+[Reader protocol]: #reader-protocol

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ end
 * **`LibSerialize:SerializeEx(opts, ...)`**
 
     Arguments:
-    * `opts`: options (see "Serialization Options")
+    * `opts`: options (see [Serialization Options])
     * `...`: a variable number of serializable values
 
     Returns:
@@ -82,13 +82,13 @@ end
     Returns:
     * `result`: `...` serialized as a string
 
-    Calls `SerializeEx(opts, ...)` with the default serialization options (see "Serialization Options")
+    Calls `SerializeEx(opts, ...)` with the default serialization options (see [Serialization Options])
 
 * **`LibSerialize:Deserialize(input[, options])`**
 
     Arguments:
     * `input`: a string previously returned from `LibSerialize:Serialize()`
-    * `options`: an optional table of options to control deserialization (see "Deserialization Options")
+    * `options`: an optional table of options to control deserialization (see [Deserialization Options])
 
     Returns:
     * `success`: a boolean indicating if deserialization was successful
@@ -98,7 +98,7 @@ end
 
     Arguments:
     * `input`: a string previously returned from `LibSerialize:Serialize()`
-    * `options`: an optional table of options to control deserialization (see "Deserialization Options")
+    * `options`: an optional table of options to control deserialization (see [Deserialization Options])
 
     Returns:
     * `...`: the deserialized value(s)
@@ -119,7 +119,7 @@ end
 This will occur if any of the following exceed 16777215: any string length,
 any table key count, number of unique strings, number of unique tables.
 It will also occur by default if any unserializable types are encountered,
-though that behavior may be disabled (see "Serialization Options").
+though that behavior may be disabled (see [Serialization Options]).
 
 `Deserialize()` and `DeserializeValue()` are equivalent, except the latter
 returns the deserialization result directly and will not catch any Lua
@@ -306,3 +306,6 @@ The type byte uses the following formats to implement the above:
     * Followed by a byte for the upper bits
 * `TTTT T000`: a 5 bit type index
     * Followed by the type-dependent payload, including count(s) if needed
+
+[Serialization Options]: #serialization-options
+[Deserialization Options]: #deserialization-options

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ end
 * **`LibSerialize:SerializeEx(opts, ...)`**
 
     Arguments:
-    * `opts`: options (see below)
+    * `opts`: options (see "Serialization Options")
     * `...`: a variable number of serializable values
 
     Returns:
@@ -82,21 +82,23 @@ end
     Returns:
     * `result`: `...` serialized as a string
 
-    Calls `SerializeEx(opts, ...)` with the default options (see below)
+    Calls `SerializeEx(opts, ...)` with the default serialization options (see "Serialization Options")
 
-* **`LibSerialize:Deserialize(input)`**
+* **`LibSerialize:Deserialize(input[, options])`**
 
     Arguments:
     * `input`: a string previously returned from `LibSerialize:Serialize()`
+    * `options`: an optional table of options to control deserialization (see "Deserialization Options")
 
     Returns:
     * `success`: a boolean indicating if deserialization was successful
     * `...`: the deserialized value(s), or a string containing the encountered Lua error
 
-* **`LibSerialize:DeserializeValue(input)`**
+* **`LibSerialize:DeserializeValue(input[, options])`**
 
     Arguments:
     * `input`: a string previously returned from `LibSerialize:Serialize()`
+    * `options`: an optional table of options to control deserialization (see "Deserialization Options")
 
     Returns:
     * `...`: the deserialized value(s)
@@ -117,19 +119,47 @@ end
 This will occur if any of the following exceed 16777215: any string length,
 any table key count, number of unique strings, number of unique tables.
 It will also occur by default if any unserializable types are encountered,
-though that behavior may be disabled (see options).
+though that behavior may be disabled (see "Serialization Options").
 
 `Deserialize()` and `DeserializeValue()` are equivalent, except the latter
 returns the deserialization result directly and will not catch any Lua
 errors that may occur when deserializing invalid input.
 
-Note that none of the serialization/deseriazation methods support reentrancy,
+Note that none of the serialization/deserialization methods support reentrancy,
 and modifying tables during the serialization process is unspecified and
 should be avoided. Table serialization is multi-phased and assumes a consistent
 state for the key/value pairs across the phases.
 
+## Deserialization Options:
+The following deserialization options are supported:
+* `readBytes`: `function(input, i, j) => string` (optional)
+  * If specified, this function will be called every time the library needs
+    to read a sequence of bytes as a string from the supplied input. The range
+    of bytes is passed in the `i` and `j` parameters, with similar semantics
+    to standard Lua functions such as `string.sub` and `table.concat`. This
+    function must return a string whose length is at-least equal to the
+    requested range of bytes.
 
-## Options:
+    It is permitted for this function to error if the range of bytes would
+    exceed the available bytes; if an error is raised it will pass through
+    the library back to the caller of Deserialize/DeserializeValue.
+* `atEnd`: `function(input, i)` (optional)
+  * If specified, this function will be called whenever the library needs to
+    test if the end of the input has been reached. The `i` parameter will be
+    supplied a byte offset from the start of the input, and should typically
+    return `true` if `i` is greater than the length of `input`.
+
+    If this function returns true, the stream is considered ended and further
+    values will not be deserialized. If this function returns false,
+    deserialization of further values will continue until it returns true.
+
+Implementations for custom functions are permitted to yield the current
+thread if deserialization is being processed within a coroutine, however this
+is only possible if the `DeserializeValue()` function was used and not
+`Deserialize()`. This is because the latter function inserts a C call
+boundary onto the call stack, preventing yields from being possible.
+
+## Serialization Options:
 The following serialization options are supported:
 * `errorOnUnserializableType`: `boolean` (default true)
   * `true`: unserializable types will raise a Lua error

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ will override default behaviors otherwise implemented by the library.
     to read a sequence of bytes as a string from the supplied input. The range
     of bytes is passed in the `i` and `j` parameters, with similar semantics
     to standard Lua functions such as `string.sub` and `table.concat`. This
-    function must return a string whose length is at-least equal to the
-    requested range of bytes.
+    function must return a string whose length is equal to the requested range
+    of bytes.
 
     It is permitted for this function to error if the range of bytes would
     exceed the available bytes; if an error is raised it will pass through

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ end
 This will occur if any of the following exceed 16777215: any string length,
 any table key count, number of unique strings, number of unique tables.
 It will also occur by default if any unserializable types are encountered,
-though that behavior may be disabled (see "Serialization Options").
+though that behavior may be disabled (see [Serialization Options]).
 
 `Deserialize()` and `DeserializeValue()` are equivalent, except the latter
 returns the deserialization result directly and will not catch any Lua

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ The following deserialization options are supported:
     It is permitted for this function to error if the range of bytes would
     exceed the available bytes; if an error is raised it will pass through
     the library back to the caller of Deserialize/DeserializeValue.
+
+    If not supplied, the default implementation will access the contents of
+    `input` as if it were a string and call `string.sub(input, i, j)`.
 * `atEnd`: `function(input, i)` (optional)
   * If specified, this function will be called whenever the library needs to
     test if the end of the input has been reached. The `i` parameter will be
@@ -152,6 +155,9 @@ The following deserialization options are supported:
     If this function returns true, the stream is considered ended and further
     values will not be deserialized. If this function returns false,
     deserialization of further values will continue until it returns true.
+
+    If not supplied, the default implementation will compare the offset `i`
+    against the length of `input` as obtained through the `#` operator.
 
 Implementations for custom functions are permitted to yield the current
 thread if deserialization is being processed within a coroutine, however this

--- a/tests.lua
+++ b/tests.lua
@@ -497,6 +497,10 @@ function LibSerialize:RunTests()
         assert(tCompare(output, value), "expected 'output' to be identical to 'value'")
     end
 
+    -- This test verifies that while reading we can throttle the rate of
+    -- processing by yielding the current thread, allowing deserialization
+    -- to be batched into chunks based on the number of bytes processed.
+
     do
         local ThrottledReader = {}
 

--- a/tests.lua
+++ b/tests.lua
@@ -383,8 +383,8 @@ function LibSerialize:RunTests()
         end
 
         local value = "banana"
-        local bytes = LibSerialize:Serialize(value) .. "WithSomeExtraData"
-        local input = CreateLimitedReader(bytes, #value)
+        local bytes = LibSerialize:Serialize(value)
+        local input = CreateLimitedReader(bytes .. "WithSomeExtraData", #bytes)
 
         local output = PackTable(LibSerialize:DeserializeValue(input))
 

--- a/tests.lua
+++ b/tests.lua
@@ -508,7 +508,7 @@ function LibSerialize:RunTests()
         function ThrottledReader:ReadBytes(i, j)
             if self.read >= self.rate then
                 coroutine.yield()
-                self.read = 0
+                self.read = self.read - self.rate
             end
 
             local length = (j - i) + 1

--- a/tests.lua
+++ b/tests.lua
@@ -181,6 +181,20 @@ function LibSerialize:RunTests()
         return true
     end
 
+    local function Mixin(obj, ...)
+        for i = 1, select("#", ...) do
+            for k, v in pairs((select(i, ...))) do
+                obj[k] = v
+            end
+        end
+
+        return obj
+    end
+
+    local function PackTable(...)
+        return { n = select("#", ...), ... }
+    end
+
 
     --[[---------------------------------------------------------------------------
         Test cases for serialization
@@ -345,23 +359,10 @@ function LibSerialize:RunTests()
         assert(success == false)
     end
 
-    -- Test cases for custom reader protocol support. All other cases should
-    -- exercise the default path of assuming a string input and no custom
-    -- reader logic.
 
-    local function Mixin(obj, ...)
-        for i = 1, select("#", ...) do
-            for k, v in pairs((select(i, ...))) do
-                obj[k] = v
-            end
-        end
-
-        return obj
-    end
-
-    local function PackTable(...)
-        return { n = select("#", ...), ... }
-    end
+    --[[---------------------------------------------------------------------------
+        Test cases for generic readers
+    --]]---------------------------------------------------------------------------
 
     -- This test will verify that we don't attempt to deserialize beyond
     -- the end of the 'data' string which has some unprocessable text

--- a/tests.lua
+++ b/tests.lua
@@ -363,10 +363,10 @@ function LibSerialize:RunTests()
             return i > #serialized
         end
 
-        local value1, value2 = LibSerialize:DeserializeValue(serializedWithPadding, { atEnd = atEnd })
+        local deserialized1, deserialized2 = LibSerialize:DeserializeValue(serializedWithPadding, { atEnd = atEnd })
 
-        assert(value1 == input)
-        assert(value2 == nil)  -- To ensure we didn't miraculously deserialize two values.
+        assert(deserialized1 == input)
+        assert(deserialized2 == nil)  -- To ensure we didn't miraculously deserialize two values.
     end
 
     -- This test verifies that we can read a sequence of chars from a table
@@ -391,10 +391,9 @@ function LibSerialize:RunTests()
             return table.concat(input, i, j)
         end
 
-        local value1, value2 = LibSerialize:DeserializeValue(chars, { readBytes = readBytes })
+        local deserialized = LibSerialize:DeserializeValue(chars, { readBytes = readBytes })
 
-        assert(tCompare(value1, input))
-        assert(value2 == nil)  -- To ensure we didn't miraculously deserialize two values.
+        assert(tCompare(input, deserialized))
     end
 
     -- This test verifies that a stream of a potentially-unknown length can


### PR DESCRIPTION
This PR extends the existing Deserialization APIs to support values implementing a "Reader" interface to be supplied in place of the previously-expected "input" string, allowing users of the library to control lower level aspects of how bytes are supplied into the library for deserialization.

This is fully backwards compatible with existing code (unlike #7), and doesn't fluff the library up with added complexity for management of coroutines as seen in #4 - such things are left to library consumers to solve. It also enables additional use cases, such as reading a subset of an input string (#6), reading input that isn't even in byte-string form to begin with, or live-processing a stream of input with potentially indeterminate length. Test cases are provided and can serve as readable examples.

---

A "Reader" is defined as any indexable object supplied as the `input` parameter to the deserialization APIs that may provide any - or all - of the functions listed below.

No explicit type restriction is placed on the the type of `input`, as technically in Lua all values can be made indexable; instead the implementation will just take advantage of duck-typing and assume that if it can be indexed without-error and if it gives back a value for any of the below keys, it's probably a Reader. Backwards compatibility isn't harmed as previously the library only supported string values being passed as `input`. This allows for an extremely simple implementation with straightforward defaults to be provided.

**ReadBytes**: `function(input, i, j) => string` (optional)
  
If specified, this function will be called every time the library needs to read a sequence of bytes as a string from the supplied input.

The inclusive range of bytes is passed in the `i` and `j` parameters, with similar semantics to standard Lua functions such as `string.sub` and `table.concat`. This function must return a string whose length is equal to the requested range of bytes.

It is permitted for this function to error if the range of bytes would exceed the available bytes; if an error is raised it will pass through the library back to the caller of Deserialize/DeserializeValue.

If not supplied, the default implementation will access the contents of `input` as if it were a string and call `string.sub(input, i, j)`.

**AtEnd**: `function(input, i) => boolean` (optional)

If specified, this function will be called whenever the library needs to test if the end of the input has been reached.

The `i` parameter will be supplied a byte offset from the start of the input, and should typically return `true` if `i` is greater than the length of `input`.

If this function returns true, the stream is considered ended and further values will not be deserialized. If this function returns false, deserialization of further values will continue until it returns true.

If not supplied, the default implementation will compare the offset `i` against the length of `input` as obtained through the `#` operator.

---

In terms of how this is accomplished, the bulk of the changes are just documentation and tests. For the implementation, there's one key change worth noting with respect to the `ReaderBytesLeft` function returned by `CreateReader` which this PR replaces with `ReaderAtEnd`.

There were only two call sites for bytes-left, of which one tested if the stream had ended and was trivially replaced, and the other was a check to see if the stream had been over-read. The latter check (with its explicit error) is removed in this PR because that error _likely_ didn't work anyway; if the existing `ReadBytes` implementation didn't return data of the expected string length it was more probable that the deserializer would have sooner errored elsewhere before it could reach this check.
