### PR TITLE
Use periods for require calls

### DIFF
--- a/tests.lua
+++ b/tests.lua
@@ -309,10 +309,10 @@ function LibSerialize:RunTests()
 
     if require then
         local versions = {
-            { "v1.0.0", require("archive\\LibSerialize-v1-0-0") },
-            { "v1.1.0", require("archive\\LibSerialize-v1-1-0") },
+            { "v1.0.0", require("archive.LibSerialize-v1-0-0") },
+            { "v1.1.0", require("archive.LibSerialize-v1-1-0") },
             -- v1.1.1 skipped due to bug with serialization version causing known failures.
-            { "v1.1.2", require("archive\\LibSerialize-v1-1-2") },
+            { "v1.1.2", require("archive.LibSerialize-v1-1-2") },
             { "latest", LibSerialize },
         }
 


### PR DESCRIPTION
For strings passed to the require function, any occurrence of period characters (.) is replaced by the first character of `package.config` which aligns with the default directory separator for the platform.

This fixes issues when running the tests on a host that isn't Windows.