### PR TITLE
Merge async APIs and generic reader/writer support

### DIFF
--- a/LibSerialize.lua
+++ b/LibSerialize.lua
@@ -101,26 +101,24 @@ end
 -- Async Mode - Used in WoW to prevent locking the game while processing.
 -- Serialize data:
 local processing = CreateFrame("Frame")
-local handler = LibSerialize:SerializeAsync(tbl)
+local handler = LibSerialize:SerializeAsync(data_to_serialize)
 processing:SetScript("OnUpdate", function()
     local completed, serialized = handler()
     if completed then
         processing:SetScript("OnUpdate", nil)
         -- Do something with `serialized`
-        end
     end
-)
+end)
 
 -- Deserialize data:
-local handler = LibSerialize:DeserializeAsync(str)
+local handler = LibSerialize:DeserializeAsync(serialized)
 processing:SetScript("OnUpdate", function()
     local completed, success, deserialized = handler()
     if completed then
         processing:SetScript("OnUpdate", nil)
         -- Do something with `deserialized`
-        end
     end
-)
+end)
 ```
 
 

--- a/LibSerialize.lua
+++ b/LibSerialize.lua
@@ -100,24 +100,24 @@ end
 
 -- Async Mode - Used in WoW to prevent locking the game while processing.
 -- Serialize data:
-local processing = CreateFrame('Frame')
+local processing = CreateFrame("Frame")
 local handler = LibSerialize:SerializeAsync(tbl)
-processing:SetScript('OnUpdate', function()
+processing:SetScript("OnUpdate", function()
     local completed, serialized = handler()
     if completed then
-        processing:SetScript('OnUpdate', nil)
-            -- Do something with `serialized`
+        processing:SetScript("OnUpdate", nil)
+        -- Do something with `serialized`
         end
     end
 )
 
 -- Deserialize data:
 local handler = LibSerialize:DeserializeAsync(str)
-processing:SetScript('OnUpdate', function()
+processing:SetScript("OnUpdate", function()
     local completed, success, deserialized = handler()
     if completed then
-        processing:SetScript('OnUpdate', nil)
-            -- Do something with `deserialized`
+        processing:SetScript("OnUpdate", nil)
+        -- Do something with `deserialized`
         end
     end
 )
@@ -152,13 +152,15 @@ processing:SetScript('OnUpdate', function()
 
     Returns:
     * `success`: a boolean indicating if deserialization was successful
-    * `...`: the deserialized value(s), or a string containing the encountered Lua error
+    * `...`: the deserialized value(s) if successful, or a string containing the encountered
+      Lua error
 
 * **`LibSerialize:DeserializeValue(input, opts)`**
 
     Arguments:
     * `input`: a string previously returned from a LibSerialize serialization API,
       or an object that implements the [Reader protocol]
+    * `opts`: options (see [Deserialization Options])
 
     Returns:
     * `...`: the deserialized value(s)
@@ -203,18 +205,19 @@ does not affect the `DeserializeValue()` function.
 * **`LibSerialize:SerializeAsyncEx(opts, ...)`**
 
     Arguments:
-    * `opts`: options (optional, see below)
+    * `opts`: options (optional, see [Serialization Options])
     * `...`: a variable number of serializable values
 
     Returns:
-    * `handler`: function to run the process. This should be run until the
-      first returned value is false.
+    * `handler`: function that performs the serialization. This should be called with
+      no arguments until the  first returned value is false.
       `handler` returns:
       * `completed`: a boolean indicating whether serialization is finished
       * `result`: once complete, `...` serialized as a string
 
     Calls `SerializeEx(opts, ...)` with the specified options, as well as setting
-    the `async` option to true (see below).
+    the `async` option to true (see [Serialization Options]). Note that the passed-in
+    table is written to when doing so.
 
 * **`LibSerialize:SerializeAsync(...)`**
 
@@ -222,36 +225,39 @@ does not affect the `DeserializeValue()` function.
     * `...`: a variable number of serializable values
 
     Returns:
-    * `handler`: function to run the process. This should be run until the
-      first returned value is false.
+    * `handler`: function that performs the serialization. This should be called with
+      no arguments until the  first returned value is false.
       `handler` returns:
       * `completed`: a boolean indicating whether serialization is finished
       * `result`: once complete, `...` serialized as a string
 
     Calls `SerializeEx(opts, ...)` with the default options, as well as setting
-    the `async` option to true (see below).
+    the `async` option to true (see [Serialization Options]). Note that the passed-in
+    table is written to when doing so.
 
 * **`LibSerialize:DeserializeAsync(input, opts)`**
 
     Arguments:
     * `input`: a string previously returned from a LibSerialize serialization API
-    * `opts`: options (optional, see below)
+    * `opts`: options (optional, see [Deserialization Options])
 
     Returns:
-    * `handler`: function to run the process. This should be run until the
-      first returned value is false.
+    * `handler`: function that performs the deserialization. This should be called with
+      no arguments until the  first returned value is false.
       `handler` returns:
       * `completed`: a boolean indicating whether deserialization is finished
       * `success`: once complete, a boolean indicating if deserialization was successful
-      * `...`: once complete, the deserialized value(s), or a string containing the
-        encountered Lua error
+      * `...`: once complete, the deserialized value(s) if successful, or a string containing
+        the encountered Lua error
 
     Calls `DeserializeValue(opts, ...)` with the specified options, as well as setting
-    the `async` option to true (see below).
+    the `async` option to true (see [Deserialization Options]). Note that the passed-in
+    table is written to when doing so.
 
 Errors encountered when serializing behave the same way as the synchronous APIs.
 Errors encountered when deserializing will always be caught and returned via the
-handler's return values, even if `DeserializeValue()` is called directly.
+handler's return values, even if `DeserializeValue()` is called directly. This is
+different than when calling `DeserializeValue()` in synchronous mode.
 
 
 ## Serialization Options
@@ -284,6 +290,8 @@ The following serialization options are supported:
     if it implements the [Writer protocol]. If so, the functions it defines
     will be used to control how serialized data is written.
 
+
+## Deserialization Options
 The following deserialization options are supported:
 * `async`: `boolean` (default false)
   * `true`: the API returns a coroutine that performs the deserialization
@@ -445,6 +453,8 @@ the following possible keys:
 
 5. You may perform the serialization and deserialization operations asynchronously,
    to avoid blocking for excessive durations when handling large amounts of data.
+   Note that you wouldn't call the handlers in a repeat-until loop like below, because
+   then you're still effectively performing the operations synchronously.
     ```lua
     local t = { "test", [false] = {} }
     t[ t[false] ] = "hello"
@@ -555,6 +565,7 @@ The type byte uses the following formats to implement the above:
     * Followed by the type-dependent payload, including count(s) if needed
 
 [Serialization Options]: #serialization-options
+[Deserialization Options]: #deserialization-options
 [Reader protocol]: #reader-protocol
 [Writer protocol]: #writer-protocol
 END_README --]]

--- a/LibSerialize.lua
+++ b/LibSerialize.lua
@@ -825,7 +825,7 @@ end
 
 -- Implements the default end-of-stream check for a reader. This requires
 -- that the supplied input object supports the length operator.
-local function HasReachedInputEnd(input, offset)
+local function GenericReader_AtEnd(input, offset)
     return offset > #input
 end
 
@@ -845,7 +845,7 @@ local function CreateReader(input, opts)
         opts = opts,
         asyncScratch = opts.async and {} or nil,
         readBytes = GetValueByKeyOrDefault(input, "ReadBytes", string_sub),
-        atEnd = GetValueByKeyOrDefault(input, "AtEnd", HasReachedInputEnd),
+        atEnd = GetValueByKeyOrDefault(input, "AtEnd", GenericReader_AtEnd),
     }
 
     return object, Reader_ReadBytes, Reader_AtEnd

--- a/README.md
+++ b/README.md
@@ -64,24 +64,24 @@ end
 
 -- Async Mode - Used in WoW to prevent locking the game while processing.
 -- Serialize data:
-local processing = CreateFrame('Frame')
+local processing = CreateFrame("Frame")
 local handler = LibSerialize:SerializeAsync(tbl)
-processing:SetScript('OnUpdate', function()
+processing:SetScript("OnUpdate", function()
     local completed, serialized = handler()
     if completed then
-        processing:SetScript('OnUpdate', nil)
-            -- Do something with `serialized`
+        processing:SetScript("OnUpdate", nil)
+        -- Do something with `serialized`
         end
     end
 )
 
 -- Deserialize data:
 local handler = LibSerialize:DeserializeAsync(str)
-processing:SetScript('OnUpdate', function()
+processing:SetScript("OnUpdate", function()
     local completed, success, deserialized = handler()
     if completed then
-        processing:SetScript('OnUpdate', nil)
-            -- Do something with `deserialized`
+        processing:SetScript("OnUpdate", nil)
+        -- Do something with `deserialized`
         end
     end
 )
@@ -116,13 +116,15 @@ processing:SetScript('OnUpdate', function()
 
     Returns:
     * `success`: a boolean indicating if deserialization was successful
-    * `...`: the deserialized value(s), or a string containing the encountered Lua error
+    * `...`: the deserialized value(s) if successful, or a string containing the encountered
+      Lua error
 
 * **`LibSerialize:DeserializeValue(input, opts)`**
 
     Arguments:
     * `input`: a string previously returned from a LibSerialize serialization API,
       or an object that implements the [Reader protocol]
+    * `opts`: options (see [Deserialization Options])
 
     Returns:
     * `...`: the deserialized value(s)
@@ -167,18 +169,19 @@ does not affect the `DeserializeValue()` function.
 * **`LibSerialize:SerializeAsyncEx(opts, ...)`**
 
     Arguments:
-    * `opts`: options (optional, see below)
+    * `opts`: options (optional, see [Serialization Options])
     * `...`: a variable number of serializable values
 
     Returns:
-    * `handler`: function to run the process. This should be run until the
-      first returned value is false.
+    * `handler`: function that performs the serialization. This should be called with
+      no arguments until the  first returned value is false.
       `handler` returns:
       * `completed`: a boolean indicating whether serialization is finished
       * `result`: once complete, `...` serialized as a string
 
     Calls `SerializeEx(opts, ...)` with the specified options, as well as setting
-    the `async` option to true (see below).
+    the `async` option to true (see [Serialization Options]). Note that the passed-in
+    table is written to when doing so.
 
 * **`LibSerialize:SerializeAsync(...)`**
 
@@ -186,36 +189,39 @@ does not affect the `DeserializeValue()` function.
     * `...`: a variable number of serializable values
 
     Returns:
-    * `handler`: function to run the process. This should be run until the
-      first returned value is false.
+    * `handler`: function that performs the serialization. This should be called with
+      no arguments until the  first returned value is false.
       `handler` returns:
       * `completed`: a boolean indicating whether serialization is finished
       * `result`: once complete, `...` serialized as a string
 
     Calls `SerializeEx(opts, ...)` with the default options, as well as setting
-    the `async` option to true (see below).
+    the `async` option to true (see [Serialization Options]). Note that the passed-in
+    table is written to when doing so.
 
 * **`LibSerialize:DeserializeAsync(input, opts)`**
 
     Arguments:
     * `input`: a string previously returned from a LibSerialize serialization API
-    * `opts`: options (optional, see below)
+    * `opts`: options (optional, see [Deserialization Options])
 
     Returns:
-    * `handler`: function to run the process. This should be run until the
-      first returned value is false.
+    * `handler`: function that performs the deserialization. This should be called with
+      no arguments until the  first returned value is false.
       `handler` returns:
       * `completed`: a boolean indicating whether deserialization is finished
       * `success`: once complete, a boolean indicating if deserialization was successful
-      * `...`: once complete, the deserialized value(s), or a string containing the
-        encountered Lua error
+      * `...`: once complete, the deserialized value(s) if successful, or a string containing
+        the encountered Lua error
 
     Calls `DeserializeValue(opts, ...)` with the specified options, as well as setting
-    the `async` option to true (see below).
+    the `async` option to true (see [Deserialization Options]). Note that the passed-in
+    table is written to when doing so.
 
 Errors encountered when serializing behave the same way as the synchronous APIs.
 Errors encountered when deserializing will always be caught and returned via the
-handler's return values, even if `DeserializeValue()` is called directly.
+handler's return values, even if `DeserializeValue()` is called directly. This is
+different than when calling `DeserializeValue()` in synchronous mode.
 
 
 ## Serialization Options
@@ -248,6 +254,8 @@ The following serialization options are supported:
     if it implements the [Writer protocol]. If so, the functions it defines
     will be used to control how serialized data is written.
 
+
+## Deserialization Options
 The following deserialization options are supported:
 * `async`: `boolean` (default false)
   * `true`: the API returns a coroutine that performs the deserialization
@@ -409,6 +417,8 @@ the following possible keys:
 
 5. You may perform the serialization and deserialization operations asynchronously,
    to avoid blocking for excessive durations when handling large amounts of data.
+   Note that you wouldn't call the handlers in a repeat-until loop like below, because
+   then you're still effectively performing the operations synchronously.
     ```lua
     local t = { "test", [false] = {} }
     t[ t[false] ] = "hello"
@@ -519,5 +529,6 @@ The type byte uses the following formats to implement the above:
     * Followed by the type-dependent payload, including count(s) if needed
 
 [Serialization Options]: #serialization-options
+[Deserialization Options]: #deserialization-options
 [Reader protocol]: #reader-protocol
 [Writer protocol]: #writer-protocol

--- a/README.md
+++ b/README.md
@@ -430,6 +430,50 @@ the following possible keys:
     assert(str == "extra")
     ```
 
+6. You may use the Reader and Writer protocols to have more control over writing the
+   results of serialization, or how those results are read when deserializing. The below
+   example implements the default behavior of the library using these protocols.
+    ```lua
+    local t = { a = 1, b = 2, c = 3 }
+
+    local StandardWriter = {}
+    function StandardWriter:Initialize()
+        self.buffer = {}
+        self.bufferSize = 0
+    end
+    function StandardWriter:WriteString(str)
+        self.bufferSize = self.bufferSize + 1
+        self.buffer[self.bufferSize] = str
+    end
+    function StandardWriter:Flush()
+        local flushed = table.concat(self.buffer, "", 1, self.bufferSize)
+        self.bufferSize = 0
+        return flushed
+    end
+
+    local StandardReader = {}
+    function StandardReader:Initialize(input)
+        self.input = input
+    end
+    function StandardReader:ReadBytes(startOffset, endOffset)
+        return string.sub(self.input, startOffset, endOffset)
+    end
+    function StandardReader:AtEnd(offset)
+        return offset > #self.input
+    end
+
+    StandardWriter:Initialize()
+    local serialized = LibSerialize:SerializeEx({ writer = StandardWriter }, t)
+
+    StandardReader:Initialize(serialized)
+    local success, tab = LibSerialize:Deserialize(StandardReader)
+
+    assert(success)
+    assert(tab.a == 1)
+    assert(tab.b == 2)
+    assert(tab.c == 3)
+    ```
+
 
 ## Encoding format
 Every object is encoded as a type byte followed by type-dependent payload.

--- a/README.md
+++ b/README.md
@@ -426,8 +426,8 @@ the following possible keys:
         completed, serialized = co_handler()
     until completed
 
-    local tab, str
-    co_handler = LibSerialize:DeserializeAsync(serialized)
+    local completed, success, tab, str
+    local co_handler = LibSerialize:DeserializeAsync(serialized)
     repeat
         completed, success, tab, str = co_handler()
     until completed

--- a/README.md
+++ b/README.md
@@ -65,26 +65,24 @@ end
 -- Async Mode - Used in WoW to prevent locking the game while processing.
 -- Serialize data:
 local processing = CreateFrame("Frame")
-local handler = LibSerialize:SerializeAsync(tbl)
+local handler = LibSerialize:SerializeAsync(data_to_serialize)
 processing:SetScript("OnUpdate", function()
     local completed, serialized = handler()
     if completed then
         processing:SetScript("OnUpdate", nil)
         -- Do something with `serialized`
-        end
     end
-)
+end)
 
 -- Deserialize data:
-local handler = LibSerialize:DeserializeAsync(str)
+local handler = LibSerialize:DeserializeAsync(serialized)
 processing:SetScript("OnUpdate", function()
     local completed, success, deserialized = handler()
     if completed then
         processing:SetScript("OnUpdate", nil)
         -- Do something with `deserialized`
-        end
     end
-)
+end)
 ```
 
 

--- a/tests.lua
+++ b/tests.lua
@@ -1,7 +1,36 @@
 local LibSerialize = LibStub and LibStub:GetLibrary("LibSerialize") or require("LibSerialize")
 
--- Compatibility with Lua 5.4
-local unpack = unpack or table.unpack
+local assert = assert
+local coroutine = coroutine
+local ipairs = ipairs
+local math = math
+local next = next
+local pairs = pairs
+local pcall = pcall
+local print = print
+local require = require
+local select = select
+local setmetatable = setmetatable
+local string = string
+local table = table
+local tonumber = tonumber
+local tostring = tostring
+local type = type
+local unpack = unpack or table.unpack -- Compatibility with Lua 5.4
+
+-- If in an environment that supports `require` and `_ENV` (note: WoW does not),
+-- then block reading/writing of globals. All needed globals should have been
+-- converted to upvalues above.
+if require and _ENV then
+    _ENV = setmetatable({}, {
+        __newindex = function(t, k, v)
+            assert(false, "Attempt to write to global variable: " .. k)
+        end,
+        __index = function(t, k)
+            assert(false, "Attempt to read global variable: " .. k)
+        end
+    })
+end
 
 function LibSerialize:RunTests()
     --[[---------------------------------------------------------------------------
@@ -71,8 +100,8 @@ function LibSerialize:RunTests()
             completed, serialized = co_handler()
         until completed
 
-        local tab, str
-        co_handler = LibSerialize:DeserializeAsync(serialized)
+        local completed, success, tab, str
+        local co_handler = LibSerialize:DeserializeAsync(serialized)
         repeat
             completed, success, tab, str = co_handler()
         until completed

--- a/tests.lua
+++ b/tests.lua
@@ -240,6 +240,20 @@ function LibSerialize:RunTests()
         return true
     end
 
+    local function Mixin(obj, ...)
+        for i = 1, select("#", ...) do
+            for k, v in pairs((select(i, ...))) do
+                obj[k] = v
+            end
+        end
+
+        return obj
+    end
+
+    local function PackTable(...)
+        return { n = select("#", ...), ... }
+    end
+
 
     --[[---------------------------------------------------------------------------
         Test cases for serialization
@@ -432,6 +446,320 @@ function LibSerialize:RunTests()
 
         local success = pcall(doAsyncSerialize, testCase)
         assert(success == false)
+    end
+
+
+    --[[---------------------------------------------------------------------------
+        Test cases for generic readers
+    --]]---------------------------------------------------------------------------
+
+    -- This test will verify that we don't attempt to deserialize beyond
+    -- the end of the 'data' string which has some unprocessable text
+    -- after it.
+
+    do
+        local LimitedReader = {}
+
+        function LimitedReader:ReadBytes(i, j)
+            return string.sub(self.bytes, i, j)
+        end
+
+        function LimitedReader:AtEnd(i)
+            return i > self.limit
+        end
+
+        local function CreateLimitedReader(bytes, limit)
+            return Mixin({ bytes = bytes, limit = limit }, LimitedReader)
+        end
+
+        local value = "banana"
+        local bytes = LibSerialize:Serialize(value)
+        local input = CreateLimitedReader(bytes .. "WithSomeExtraData", #bytes)
+
+        local output = PackTable(LibSerialize:DeserializeValue(input))
+
+        assert(output.n == 1, "expected one value to be deserialized")
+        assert(output[1] == value, "expected original value to be deserialized")
+    end
+
+    -- This test verifies that we can read a sequence of numeric bytes from a
+    -- table as our input stream. No custom 'AtEnd' logic is needed as the
+    -- table will support the default length operator test.
+
+    do
+        local ByteReader = {}
+
+        function ByteReader:ReadBytes(i, j)
+            assert(i >= 1)      -- 'i' should always be a non-zero positive integer.
+            assert(j >= i)      -- 'j' will always be after or at the same place as 'i'
+            assert(j <= #self)  -- 'j' will never exceed the length of the input.
+
+            return table.concat({ string.char(unpack(self, i, j)) }, "")
+        end
+
+        local function CreateByteReader(bytes)
+            return Mixin({ string.byte(bytes, 1, #bytes) }, ByteReader)
+        end
+
+        local value = { 1, true, false, "banana" }
+        local bytes = LibSerialize:Serialize(value)
+        local input = CreateByteReader(bytes)
+
+        local output = LibSerialize:DeserializeValue(input)
+
+        assert(tCompare(output, value), "expected 'output' to be identical to 'value'")
+    end
+
+    -- This test verifies that a stream of a potentially-unknown length can
+    -- be fed through LibSerialize, such as reading data from a network and
+    -- processing it within a coroutine.
+
+    do
+        local StreamReader = {}
+
+        function StreamReader:ReadBytes(i, j)
+            -- For testing simplicity, our "bytes" buffer is just append-only.
+
+            while self.canReadMore and j > #self.bytes do
+                local bytes, finished = assert(coroutine.yield())
+                self.bytes = self.bytes .. bytes
+                self.canReadMore = not finished
+            end
+
+            return string.sub(self.bytes, i, j)
+        end
+
+        function StreamReader:AtEnd(i)
+            return not self.canReadMore and i > #self.bytes
+        end
+
+        local function CreateStreamReader()
+            return Mixin({ canReadMore = true, bytes = "" }, StreamReader)
+        end
+
+        -- Use a large table for 'value' with a large range of numbers as
+        -- this gives the best coverage for testing multiple ReadBytes
+        -- calls between each yield, as well as a good range of sizes for
+        -- the range (i, j).
+
+        local value = {}
+
+        for i = 1, 1000 do
+            value[i] = i * 1000
+        end
+
+        local bytes = LibSerialize:Serialize(value)
+        local input = CreateStreamReader()
+        local thread = coroutine.create(function() return LibSerialize:DeserializeValue(input) end)
+
+        -- The thread is expected to suspend on the first call into ReadBytes.
+
+        assert(coroutine.resume(thread))
+        assert(coroutine.status(thread) == "suspended", "expected 'thread' to have suspended")
+
+        -- Now resume the thread repeatedly feeding in a large chunk each
+        -- time it yields back to us, until we've run out of data.
+
+        local output
+
+        do
+            local remaining = bytes
+            local chunkSize = 100
+
+            while remaining ~= "" do
+                local chunk = string.sub(remaining, 1, chunkSize)
+                local after = string.sub(remaining, chunkSize + 1)
+                local finished = (after == "")
+                local ok
+
+                ok, output = coroutine.resume(thread, chunk, finished)
+                assert(ok, output)  -- If not ok, 'output' will be an error.
+
+                remaining = after
+            end
+        end
+
+        -- At this point the thread is expected to be dead and we should have
+        -- obtained the result of deserialization.
+
+        assert(coroutine.status(thread) == "dead", "expected 'thread' to have finished executing")
+        assert(type(output) == type(value), "expected 'output' to be same type as 'value'")
+        assert(tCompare(output, value), "expected 'output' to be identical to 'value'")
+    end
+
+    -- This test verifies that while reading we can throttle the rate of
+    -- processing by yielding the current thread, allowing deserialization
+    -- to be batched into chunks based on the number of bytes processed.
+
+    do
+        local ThrottledReader = {}
+
+        function ThrottledReader:ReadBytes(i, j)
+            if self.read >= self.rate then
+                coroutine.yield()
+                self.read = self.read - self.rate
+            end
+
+            local length = (j - i) + 1
+            self.read = self.read + length
+            return string.sub(self.bytes, i, j)
+        end
+
+        function ThrottledReader:AtEnd(i)
+            return i > #self.bytes
+        end
+
+        local function CreateThrottledReader(bytes, rate)
+            return Mixin({ bytes = bytes, rate = rate, read = 0 }, ThrottledReader)
+        end
+
+        -- Use a large table for 'value' so that the thread the deserializer
+        -- runs into will yield a good number of times.
+
+        local value = {}
+
+        for i = 1, 1000 do
+            value[i] = i * 1000
+        end
+
+        local bytes = LibSerialize:Serialize(value)
+        local input = CreateThrottledReader(bytes, 256)
+        local thread = coroutine.create(function() return LibSerialize:DeserializeValue(input) end)
+
+        -- This test mostly serves as an example, but...
+
+        local output
+
+        while coroutine.status(thread) ~= "dead" do
+            local ok
+            ok, output = coroutine.resume(thread)
+            assert(ok, output)  -- If not ok, 'output' will be an error.
+        end
+
+        assert(type(output) == type(value), "expected 'output' to be same type as 'value'")
+        assert(tCompare(output, value), "expected 'output' to be identical to 'value'")
+    end
+
+
+    --[[---------------------------------------------------------------------------
+        Test cases for generic writers
+    --]]---------------------------------------------------------------------------
+
+    -- This test verifies the basic functionality of a custom writer that
+    -- writes to a reusable buffer and returns its concatenated result to
+    -- the serializer.
+
+    do
+        local PersistentBuffer = {}
+
+        function PersistentBuffer:WriteString(str)
+            self.n = self.n + 1
+            self[self.n] = str
+        end
+
+        function PersistentBuffer:Flush()
+            local flushed = table.concat(self, "", 1, self.n)
+            self.n = 0
+            return flushed
+        end
+
+        local function CreatePersistentBuffer()
+            return Mixin({ n = 0 }, PersistentBuffer)
+        end
+
+        local value = { 1, 2, 3, 4, 5, true, false, "banana" }
+        local writer = CreatePersistentBuffer()
+        local bytes = LibSerialize:SerializeEx({ writer = writer }, value)
+
+        assert(type(bytes) == "string", "expected 'bytes' to be a string")
+        assert(writer.n == 0, "expected 'writer' to have been flushed")
+
+        local output = LibSerialize:DeserializeValue(bytes)
+
+        assert(type(output) == type(value), "expected 'output' to be of the same type as 'value'")
+        assert(tCompare(output, value), "expected 'output' to be fully comparable to 'value'")
+    end
+
+    -- This test verifies that if no Flush implementation is given, the default
+    -- will return nothing from the Serialize function. As documented in the
+    -- library, it's expected that such a writer would likely be submitting
+    -- string as it gets them to another destination.
+
+    do
+        local NullWriter = {}
+
+        function NullWriter:WriteString(str)
+            assert(type(str) == "string")  -- 'str' should always be a string
+            self.writes = self.writes + 1
+        end
+
+        local function CreateNullWriter()
+            return Mixin({ writes = 0 }, NullWriter)
+        end
+
+        local value = { 1, 2, 3, 4, 5, true, false, "banana" }
+        local writer = CreateNullWriter()
+        local result = PackTable(LibSerialize:SerializeEx({ writer = writer }, value))
+
+        assert(result.n == 0, "expected no return values from 'SerializeEx' call")
+        assert(writer.writes > 0, "expected 'WriteString' to have been called at least once")
+    end
+
+    -- This test verifies that the pace at which serialization occurs can be
+    -- throttled within a coroutine.
+
+    do
+        local ThrottledWriter = {}
+
+        function ThrottledWriter:WriteString(str)
+            if self.written > self.rate then
+                coroutine.yield()
+                self.written = self.written - self.rate
+            end
+
+            local length = #str
+            self.written = self.written + length
+            self.size = self.size + 1
+            self.buffer[self.size] = str
+        end
+
+        function ThrottledWriter:Flush()
+            local flushed = table.concat(self.buffer, "", 1, self.size)
+            self.size = 0
+            return flushed
+        end
+
+        local function CreateThrottledWriter(rate)
+            return Mixin({ buffer = {}, size = 0, written = 0, rate = rate }, ThrottledWriter)
+        end
+
+        -- Use a large table for 'value' so that the thread the serializer
+        -- yields a few times.
+
+        local value = {}
+
+        for i = 1, 1000 do
+            value[i] = i * 1000
+        end
+
+        local writer = CreateThrottledWriter(100)
+        local thread = coroutine.create(function() return LibSerialize:SerializeEx({ writer = writer }, value) end)
+
+        local bytes
+
+        while coroutine.status(thread) ~= "dead" do
+            local ok
+            ok, bytes = coroutine.resume(thread)
+            assert(ok, bytes)  -- If not ok, 'bytes' will be an error.
+        end
+
+        assert(type(bytes) == "string", "expected 'bytes' to be a string")
+        assert(writer.size == 0, "expected 'writer' to have been flushed")
+
+        local output = LibSerialize:DeserializeValue(bytes)
+
+        assert(type(output) == type(value), "expected 'output' to be of the same type as 'value'")
+        assert(tCompare(output, value), "expected 'output' to be fully comparable to 'value'")
     end
 
     print("All tests passed!")


### PR DESCRIPTION
This PR continues the work from @oratory in #4. The API surface is unchanged, but the following updates were made:

* Revised the documentation for the new APIs
* Fixed the new sample code and added to test suite
* Made `async` an option and renamed `yieldCheckFn` to `yieldCheck`
* Fixed handling of trailing `nil`s for serialization input
* Fixed test code interfering with NaN tests
* Optimized creation of closures and temporary tables
* Async serialization will now raise errors in the same way as synchronous serialization
* Library are now compatible with Lua 5.4

This PR also merges in the generic reader/writer support from @Meorawr in #12. The API surface is again unchanged, but I revised the implementation a bit as I was combining it with the above work.