### PR TITLE
Disable failing compat test for NaN values

### DIFF
--- a/tests.lua
+++ b/tests.lua
@@ -265,7 +265,7 @@ function LibSerialize:RunTests()
         { -1.5, 6 },
         { -123.45678901235, 10 },
         { -148921291233.23, 10 },
-        { 0/0, 10 },  -- -1.#IND or -nan(ind)
+        { 0/0, 10, nil, 3 },  -- -1.#IND or -nan(ind)
         { 1/0, 10, nil, 3 },  -- 1.#INF or inf
         { -1/0, 10, nil, 3 }, -- -1.#INF or -inf
         { "", 2 },


### PR DESCRIPTION
The serialization behaviour of NaN values in certain environments changed between releases a bit.

Prior to v1.1.2 NaNs weren't correctly detected in the in-game environment, therefore any test case that compares the serialization of NaNs across a version older than v1.1.2 to that version or newer will always fail in such an environment.

As such - we can just mark that specific test case as having a minimum lower version bound similar to the infinity cases.