### PR TITLE
Fix (de)serialization edge cases: large ints, subnormals, negative zero, stable sort

### DIFF
--- a/archive/LibSerialize-v1-2-1.lua
+++ b/archive/LibSerialize-v1-2-1.lua
@@ -601,7 +601,6 @@ local math_floor = math.floor
 local math_huge = math.huge
 local math_max = math.max
 local math_modf = math.modf
-local math_type = math.type -- nil prior to Lua 5.3 (e.g. WoW's 5.1)
 local pairs = pairs
 local pcall = pcall
 local print = print
@@ -770,46 +769,33 @@ end
 local function Noop()
 end
 
--- Ordering of key types for stable map serialization. We arbitrarily put
--- strings first, then numbers, then booleans, and finally all reference types
--- (tables, functions, threads, userdata) which share the last rank.
-local stableKeyTypeRank = {
-    ["string"] = 1,
-    ["number"] = 2,
-    ["boolean"] = 3,
-}
-
 -- Sort compare function which is used to sort table keys to ensure that the
--- serialization of maps is stable. Keys are ordered first by type, and then
--- by value where a meaningful value ordering exists.
---
--- Reference-type keys (tables, functions, etc.) have no value ordering, so
--- they're ordered by their string representation purely to provide a total,
--- crash-free ordering within a single serialization. As a result, maps keyed
--- by reference types are not guaranteed to serialize identically across
--- separate runs even with the `stable` option enabled.
+-- serialization of maps is stable. We arbitrarily put strings first, then
+-- numbers, and finally booleans.
 local function StableKeySort(a, b)
     local aType = type(a)
     local bType = type(b)
-    local aRank = stableKeyTypeRank[aType] or 4
-    local bRank = stableKeyTypeRank[bType] or 4
-
-    if aRank ~= bRank then
-        return aRank < bRank
-    end
-
-    -- Same ranking; compare within the type.
-    if aType == "string" or aType == "number" then
+    -- Put strings first
+    if aType == "string" and bType == "string" then
         return a < b
-    elseif aType == "boolean" then
+    elseif aType == "string" then
+        return true
+    elseif bType == "string" then
+        return false
+    end
+    -- Put numbers next
+    if aType == "number" and bType == "number" then
+        return a < b
+    elseif aType == "number" then
+        return true
+    elseif bType == "number" then
+        return false
+    end
+    -- Put booleans last
+    if aType == "boolean" and bType == "boolean" then
         return (a and 1 or 0) < (b and 1 or 0)
-    elseif aType ~= bType then
-        -- Distinct reference types (e.g. table vs function); order by type name.
-        return aType < bType
     else
-        -- Same reference type; order by string representation. Distinct objects
-        -- have distinct representations, so this is a strict ordering.
-        return tostring(a) < tostring(b)
+        error(("Unhandled sort type(s): %s, %s"):format(aType, bType))
     end
 end
 
@@ -957,24 +943,11 @@ local function FloatToString(n)
         else -- -inf
             return string_char(0xFF, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
         end
-    elseif mant == 0.0 and expo == 0 then -- zero
+    elseif (mant == 0.0 and expo == 0) or expo < -0x3FE then -- zero
         return string_char(sign, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
     else
-        local fraction = mant
         expo = expo + 0x3FE
-        if expo <= 0 then
-            -- Subnormal (denormal) value, or an underflow to true zero. On read
-            -- these are reconstructed as (mant / 2^52) * 2^-1022, so derive the
-            -- 52-bit significand directly from the frexp fraction rather than
-            -- flushing the value to zero.
-            mant = math_floor(ldexp(fraction, expo + 52) + 0.5)
-            if mant == 0 then
-                return string_char(sign, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
-            end
-            expo = 0
-        else
-            mant = math_floor((fraction * 2.0 - 1.0) * ldexp(0.5, 53))
-        end
+        mant = math_floor((mant * 2.0 - 1.0) * ldexp(0.5, 53))
         return string_char(sign + math_floor(expo / 0x10),
                            (expo % 0x10) * 0x10 + math_floor(mant / 281474976710656),
                            math_floor(mant / 1099511627776) % 256,
@@ -1005,9 +978,6 @@ local function StringToFloat(str)
         else
             n = 0.0/0.0
         end
-    elseif expo == 0 then
-        -- Subnormal (denormal): no implicit leading one, fixed exponent.
-        n = sign * ldexp(mant / 4503599627370496.0, -0x3FE)
     else
         n = sign * ldexp(1.0 + mant / 4503599627370496.0, expo - 0x3FF)
     end
@@ -1223,10 +1193,8 @@ function LibSerializeInt:_ReadObject()
     local value = self:_ReadByte()
 
     if value % 2 == 1 then
-        -- Number embedded in the top 7 bits. math_floor keeps the integer
-        -- subtype on Lua 5.3+ (the division is exact); it's a value-preserving
-        -- no-op on 5.1 where all numbers are doubles.
-        local num = math_floor((value - 1) / 2)
+        -- Number embedded in the top 7 bits.
+        local num = (value - 1) / 2
         -- DebugPrint("Found embedded number (1byte):", value, num)
         return num
     end
@@ -1247,9 +1215,9 @@ function LibSerializeInt:_ReadObject()
         local packed = self:_ReadByte() * 256 + value
         local num
         if value % 16 == 12 then
-            num = math_floor(-(packed - 12) / 16)
+            num = -(packed - 12) / 16
         else
-            num = math_floor((packed - 4) / 16)
+            num = (packed - 4) / 16
         end
         -- DebugPrint("Found embedded number (2bytes):", value, packed, num)
         return num
@@ -1361,7 +1329,7 @@ LibSerializeInt._ReaderIndex = {
     NUM_64_POS = 7,
     NUM_64_NEG = 8,
     NUM_FLOAT = 9,
-    NUM_FLOATSTR = 10,
+    NUM_FLOATSTR_POS = 10,
     NUM_FLOATSTR_NEG = 11,
 
     BOOL_T = 12,
@@ -1405,7 +1373,7 @@ LibSerializeInt._ReaderTable = {
     [LibSerializeInt._ReaderIndex.NUM_64_POS] = function(self) return self:_ReadInt(7) end,
     [LibSerializeInt._ReaderIndex.NUM_64_NEG] = function(self) return -self:_ReadInt(7) end,
     [LibSerializeInt._ReaderIndex.NUM_FLOAT]  = function(self) return StringToFloat(self._readBytes(self._reader, 8)) end,
-    [LibSerializeInt._ReaderIndex.NUM_FLOATSTR]  = function(self) return tonumber(self._readBytes(self._reader, self:_ReadByte())) end,
+    [LibSerializeInt._ReaderIndex.NUM_FLOATSTR_POS]  = function(self) return tonumber(self._readBytes(self._reader, self:_ReadByte())) end,
     [LibSerializeInt._ReaderIndex.NUM_FLOATSTR_NEG]  = function(self) return -tonumber(self._readBytes(self._reader, self:_ReadByte())) end,
 
     -- Booleans
@@ -1552,48 +1520,7 @@ LibSerializeInt._WriterTable = {
         self:_WriteByte(readerIndexShift * self._ReaderIndex.NIL)
     end,
     ["number"] = function(self, num)
-        -- Preserve negative zero, which the integer/embedded paths would
-        -- otherwise collapse to +0. There's no compact type code for it, so
-        -- encode it as a fixed "-0.0" via NUM_FLOATSTR: 7 bytes total, decoded
-        -- by tonumber back to -0.0 on Lua 5.1 through 5.4, and readable by older
-        -- deserializers. A literal "-0.0" is used rather than tostring(num),
-        -- whose output for negative zero varies by runtime ("-0" vs "-0.0") and
-        -- would not round-trip across runtimes.
-        if num == 0 and 1 / num < 0 then
-            local negativeZero = "-0.0"
-            self:_WriteByte(readerIndexShift * self._ReaderIndex.NUM_FLOATSTR)
-            self:_WriteByte(#negativeZero, 1)
-            self._writeString(self._writer, negativeZero)
-            return
-        end
-
-        -- Exact encoding for large integer-subtype values (Lua 5.3+). Integers
-        -- with magnitude > 2^53 can't be represented exactly by the double-based
-        -- numeric paths, so serialize them as their decimal string, which
-        -- tonumber decodes back to the exact integer. This reuses the existing
-        -- NUM_FLOATSTR type (with the full signed string under the "positive"
-        -- code, so math.mininteger needs no problematic negation), meaning even
-        -- older deserializers can read the result.
-        if math_type and math_type(num) == "integer"
-           and (num > 9007199254740992 or num < -9007199254740992) then
-            local asString = tostring(num)
-            self:_WriteByte(readerIndexShift * self._ReaderIndex.NUM_FLOATSTR)
-            self:_WriteByte(#asString, 1)
-            self._writeString(self._writer, asString)
-            return
-        end
-
-        -- Whole numbers whose magnitude is too large for the 56-bit integer
-        -- encoding (|num| >= 2^56) are stored as doubles instead, to avoid
-        -- silently truncating them. Forcing a float subtype here also avoids
-        -- integer negation overflow further below (e.g. -math.mininteger).
-        local useFloat = IsFloatingPoint(num)
-        if not useFloat and (num >= 72057594037927936 or num <= -72057594037927936) then
-            useFloat = true
-            num = num + 0.0
-        end
-
-        if useFloat then
+        if IsFloatingPoint(num) then
             -- DebugPrint("Serializing float:", num)
             -- Normally a float takes 8 bytes. See if it's cheaper to encode as a string.
             -- If we encode as a string, though, we'll need a byte for its length.
@@ -1609,7 +1536,7 @@ LibSerializeInt._WriterTable = {
             end
             local asString = tostring(numAbs)
             if #asString < 7 and tonumber(asString) == numAbs and IsFinite(numAbs) then
-                self:_WriteByte(sign + readerIndexShift * self._ReaderIndex.NUM_FLOATSTR)
+                self:_WriteByte(sign + readerIndexShift * self._ReaderIndex.NUM_FLOATSTR_POS)
                 self:_WriteByte(#asString, 1)
                 self._writeString(self._writer, asString)
             else
@@ -1691,7 +1618,7 @@ LibSerializeInt._WriterTable = {
 
             local filter
             local mt = getmetatable(tab)
-            if mt and type(mt) == "table" and type(mt.__LibSerialize) == "table" then
+            if mt and type(mt) == "table" and mt.__LibSerialize then
                 filter = mt.__LibSerialize.filter
             end
 
@@ -1872,7 +1799,7 @@ LibSerializeInt._WriterTable = {
 local serializeTester = CreateSerializer(canSerializeFnOptions)
 
 function LibSerialize:IsSerializableType(...)
-    return serializeTester:_CanSerialize(...)
+    return serializeTester:_CanSerialize(canSerializeFnOptions, ...)
 end
 
 function LibSerialize:SerializeEx(opts, ...)
@@ -1881,6 +1808,8 @@ function LibSerialize:SerializeEx(opts, ...)
     if opts.async then
         local ser = CreateSerializer(opts, ...)
         local thread = coroutine_create(Serialize)
+        local inputSize = select("#", ...)
+        local input = {...}
 
         -- return coroutine handler
         return function()

--- a/tests.lua
+++ b/tests.lua
@@ -196,35 +196,64 @@ function LibSerialize:RunTests()
         assert(tab1[false][3] == 3)
         assert(tab1[false].a == "b")
 
-        -- make a copy of the original table, but first insert a bunch of extra keys (which we'll
-        -- filter out) to force the order of the hashes to be different (tested with lua 5.1 and 5.2)
-        local t2 = {}
-        for i = 100, 10000 do
-            t2[tostring(i)] = i
-        end
-        t2.x = "y"
-        t2[1] = "test"
-        t2[false] = { 1, 2, 3, a = "b" }
+        -- Make a copy of the original table, but first insert a bunch of extra
+        -- keys (which we'll filter out) to force the order of the hashes to be
+        -- different. Modern Lua runtimes randomize the string-hash seed per
+        -- process, so a given construction's iteration order isn't predictable;
+        -- we retry with varying filler until we observe a different iteration
+        -- order, which is what makes the stability check meaningful.
+        --
+        -- Each attempt uses a distinct range of numeric-string keys (so the
+        -- shared keys collide/land differently) and a filler count that spans
+        -- several hash-table capacity boundaries. All filler keys are numeric
+        -- and >= 100, so the `opts` filter removes them from the serialization.
+        local fillerSizes = { 3, 7, 15, 31, 63, 127, 255, 511, 1023, 2047, 4095, 8191, 16383 }
 
-        -- ensure the iteration order is different
-        local isDifferent = false
-        local k1, k2 = nil, nil
-        while true do
-            k1 = next(t1, k1)
-            -- get the next key from t2 that's not going to be filtered
+        local function buildCopy(attempt)
+            local t2 = {}
+            local base = 100 + attempt * 100000
+            local count = fillerSizes[((attempt - 1) % #fillerSizes) + 1]
+            for i = 0, count - 1 do
+                t2[tostring(base + i)] = i
+            end
+            t2.x = "y"
+            t2[1] = "test"
+            t2[false] = { 1, 2, 3, a = "b" }
+            return t2
+        end
+
+        local function iteratesDifferently(t2)
+            local isDifferent = false
+            local k1, k2 = nil, nil
             while true do
-                k2 = next(t2, k2)
-                if k2 == nil or not tonumber(k2) or tonumber(k2) < 100 then
+                k1 = next(t1, k1)
+                -- get the next key from t2 that's not going to be filtered
+                while true do
+                    k2 = next(t2, k2)
+                    if k2 == nil or not tonumber(k2) or tonumber(k2) < 100 then
+                        break
+                    end
+                end
+                if k1 == nil and k2 == nil then
                     break
                 end
+                assert(k1 ~= nil and k2 ~= nil)
+                isDifferent = isDifferent or k1 ~= k2
             end
-            if k1 == nil and k2 == nil then
+            return isDifferent
+        end
+
+        -- ensure the iteration order is different, retrying a bounded number of
+        -- times to be robust against hash-seed randomization
+        local t2, isDifferent
+        for attempt = 1, 100 do
+            t2 = buildCopy(attempt)
+            if iteratesDifferently(t2) then
+                isDifferent = true
                 break
             end
-            assert(k1 ~= nil and k2 ~= nil)
-            isDifferent = isDifferent or k1 ~= k2
         end
-        assert(isDifferent)
+        assert(isDifferent, "could not produce a differing iteration order after 100 attempts")
 
         -- serialize the copy and ensure the result is the same
         local serialized2 = LibSerialize:SerializeEx(opts, t2)
@@ -523,8 +552,10 @@ function LibSerialize:RunTests()
                 fail(index, fromVer, toVer, value, ("Deserialization failed: %s"):format(deserialized), true)
             end
 
-            -- Tests involving NaNs will be compared in string form.
-            if type(value) == "number" and isnan(value) then
+            -- Tests involving NaNs or negative zero will be compared in string
+            -- form: `==` treats NaN as unequal to itself and -0.0 as equal to
+            -- +0.0, so a direct comparison can't distinguish either case.
+            if type(value) == "number" and (isnan(value) or (value == 0 and 1 / value < 0)) then
                 value = tostring(value)
                 deserialized = tostring(deserialized)
             end
@@ -570,7 +601,7 @@ function LibSerialize:RunTests()
             { 27.32, 8 },
             { 123.45678901235, 10 },
             { 148921291233.23, 10 },
-            { -0, 2 },
+            { -1 / math.huge, 7, nil, 6 }, -- -0.0
             { -1, 3 },
             { -4095, 3 },
             { -4096, 4 },
@@ -633,6 +664,7 @@ function LibSerialize:RunTests()
                 -- v1.1.1 skipped due to bug with serialization version causing known failures.
                 { "v1.1.2", require("archive.LibSerialize-v1-1-2") },
                 { "v1.1.3", require("archive.LibSerialize-v1-1-3") },
+                { "v1.2.1", require("archive.LibSerialize-v1-2-1") },
                 { "latest", LibSerialize },
             }
 
@@ -966,6 +998,195 @@ function LibSerialize:RunTests()
         assert(type(output) == type(value), "expected 'output' to be of the same type as 'value'")
         assert(tCompare(output, value), "expected 'output' to be fully comparable to 'value'")
     end
+
+    --[[---------------------------------------------------------------------------
+        Regression: stable serialization with reference-type keys
+    --]]---------------------------------------------------------------------------
+
+    -- Sorting map keys for `stable` serialization previously errored whenever a
+    -- table contained two or more keys whose types have no value ordering
+    -- (tables, functions, ...) or an incomparable mix (e.g. boolean + table).
+
+    do
+        local k1, k2 = {}, {}
+        local value = { [k1] = "one", [k2] = "two", plain = 3 }
+
+        local bytes = LibSerialize:SerializeEx({ stable = true }, value)
+        local success, out = LibSerialize:Deserialize(bytes)
+        assert(success, "stable serialization with table keys should not error")
+        assert(out.plain == 3, "expected plain key to round-trip")
+
+        local tableKeyCount, seenValues = 0, {}
+        for k, v in pairs(out) do
+            if type(k) == "table" then
+                tableKeyCount = tableKeyCount + 1
+                seenValues[v] = true
+            end
+        end
+        assert(tableKeyCount == 2, "expected two table keys to round-trip")
+        assert(seenValues["one"] and seenValues["two"], "expected table-key values to round-trip")
+
+        -- Determinism within a run: re-serializing the same object is identical.
+        assert(LibSerialize:SerializeEx({ stable = true }, value) == bytes,
+            "expected stable serialization to be deterministic within a run")
+
+        -- Mixed incomparable key types (boolean vs table, table vs table).
+        local mixed = { [true] = 1, [{}] = 2, [{}] = 3, s = "x" }
+        assert(pcall(LibSerialize.SerializeEx, LibSerialize, { stable = true }, mixed),
+            "stable serialization with mixed incomparable keys should not error")
+
+        -- Two reference-type keys surviving a filter must still sort cleanly.
+        local filtered = { [{}] = 1, [{}] = 2, [print] = 3 }
+        assert(pcall(LibSerialize.SerializeEx, LibSerialize,
+            { stable = true, errorOnUnserializableType = false }, filtered),
+            "stable serialization must not crash when sorting filtered reference keys")
+    end
+
+
+    --[[---------------------------------------------------------------------------
+        Regression: whole numbers too large for the integer encoding
+    --]]---------------------------------------------------------------------------
+
+    -- Whole numbers with magnitude >= 2^56 don't fit the 56-bit integer encoding
+    -- and were previously truncated silently (and math.mininteger errored). They
+    -- now fall back to the lossless double encoding.
+
+    do
+        local function roundtrip(value)
+            local success, out = LibSerialize:Deserialize(LibSerialize:Serialize(value))
+            assert(success, "expected large-number serialization to succeed")
+            return out
+        end
+
+        -- Whole doubles too large for the 56-bit integer encoding round-trip
+        -- exactly via the lossless double encoding.
+        assert(roundtrip(2^56) == 2^56, "expected 2^56 to round-trip")
+        assert(roundtrip(-(2^56)) == -(2^56), "expected -2^56 to round-trip")
+        assert(roundtrip(2^60) == 2^60, "expected 2^60 to round-trip")
+        assert(roundtrip(2^63) == 2^63, "expected 2^63 to round-trip")
+
+        -- 2^53 is the largest power of two still handled by the exact integer
+        -- byte path (values below the 2^56 float-fallback threshold).
+        assert(roundtrip(9007199254740992) == 9007199254740992,
+            "expected 2^53 to round-trip via the integer path")
+
+        -- Native 64-bit integers (Lua 5.3+) are encoded as their exact decimal
+        -- string, so they round-trip exactly and preserve the integer subtype.
+        if math.maxinteger then
+            local integerCases = {
+                9007199254740993,     -- 2^53 + 1
+                72057594037927935,    -- 2^56 - 1 (previously corrupted to 255)
+                72057594037927937,    -- 2^56 + 1
+                1152921504606846977,  -- 2^60 + 1
+                1311768467294899695,  -- 0x1234567890ABCDEF
+                math.maxinteger,      -- 2^63 - 1
+                math.mininteger,      -- -2^63
+            }
+            for _, value in ipairs(integerCases) do
+                local out = roundtrip(value)
+                assert(out == value,
+                    ("expected integer %s to round-trip exactly (got %s)"):format(
+                        tostring(value), tostring(out)))
+                assert(math.type(out) == "integer",
+                    ("expected %s to remain an integer"):format(tostring(value)))
+            end
+        end
+    end
+
+
+    --[[---------------------------------------------------------------------------
+        Regression: subnormal (denormal) floating point values
+    --]]---------------------------------------------------------------------------
+
+    -- Subnormal values were previously flushed to zero on serialization.
+
+    do
+        local function roundtrip(value)
+            local success, out = LibSerialize:Deserialize(LibSerialize:Serialize(value))
+            assert(success, "expected subnormal serialization to succeed")
+            return out
+        end
+
+        local smallestSubnormal = 2^-1074
+        local largestSubnormal = (2^-1022) - (2^-1074)
+
+        assert(smallestSubnormal ~= 0, "sanity: smallest subnormal is non-zero")
+        assert(roundtrip(smallestSubnormal) == smallestSubnormal,
+            "expected smallest subnormal to round-trip")
+        assert(roundtrip(-smallestSubnormal) == -smallestSubnormal,
+            "expected negative smallest subnormal to round-trip")
+        assert(roundtrip(2^-1050) == 2^-1050, "expected mid-range subnormal to round-trip")
+        assert(roundtrip(2^-1023) == 2^-1023, "expected subnormal near boundary to round-trip")
+        assert(roundtrip(largestSubnormal) == largestSubnormal,
+            "expected largest subnormal to round-trip")
+
+        -- The smallest normal value must remain unaffected.
+        assert(roundtrip(2^-1022) == 2^-1022, "expected smallest normal to round-trip")
+    end
+
+
+    --[[---------------------------------------------------------------------------
+        Regression: non-table __LibSerialize metatable field
+    --]]---------------------------------------------------------------------------
+
+    -- A non-table (but truthy) __LibSerialize field was indexed unconditionally,
+    -- raising an error. It should now be ignored gracefully.
+
+    do
+        for _, marker in ipairs({ true, 42, "nope" }) do
+            local value = setmetatable({ a = 1, b = 2 }, { __LibSerialize = marker })
+            local success, out = LibSerialize:Deserialize(LibSerialize:Serialize(value))
+            assert(success, "expected serialization to ignore non-table __LibSerialize")
+            assert(out.a == 1 and out.b == 2, "expected contents to round-trip")
+        end
+    end
+
+
+    --[[---------------------------------------------------------------------------
+        Regression: integer subtype preservation (Lua 5.3+)
+    --]]---------------------------------------------------------------------------
+
+    -- Embedded integers previously decoded as floats (the decoder used float
+    -- division), so `math.type` wasn't preserved and was inconsistent across the
+    -- value range. All integer values should now decode back as integers, across
+    -- every encoding path (embedded 7-bit / 12-bit, multi-byte, decimal string).
+
+    do
+        if math.type then
+            local integerValues = {
+                0, 1, 127,                       -- embedded 7-bit
+                128, 4095, -1, -128, -4095,      -- embedded 12-bit (+/-)
+                4096, 65535, -4096, -65535,      -- 16-bit
+                65536, 16777215, -16777215,      -- 24-bit
+                16777216, 4294967295, -4294967295, -- 32-bit
+                4294967296, 9007199254740992,    -- 56-bit (<= 2^53)
+                -9007199254740992,
+                9007199254740993, -- 2^53 + 1 (decimal string path)
+                72057594037927935, -- 2^56 - 1
+                math.maxinteger, math.mininteger,
+            }
+            for _, value in ipairs(integerValues) do
+                local ok, out = LibSerialize:Deserialize(LibSerialize:Serialize(value))
+                assert(ok, "expected integer serialization to succeed")
+                assert(out == value,
+                    ("expected %s to round-trip"):format(tostring(value)))
+                assert(math.type(out) == "integer",
+                    ("expected %s to decode as an integer (got %s)"):format(
+                        tostring(value), math.type(out) or "nil"))
+            end
+
+            -- Whole-valued floats normalize to integers (the format doesn't
+            -- distinguish 2 from 2.0); fractional and non-finite values stay floats.
+            assert(math.type((select(2, LibSerialize:Deserialize(LibSerialize:Serialize(2.0))))) == "integer",
+                "expected whole float 2.0 to normalize to an integer")
+            for _, value in ipairs({ 1.5, -27.32, 1/0, -1/0, 0/0 }) do
+                local ok, out = LibSerialize:Deserialize(LibSerialize:Serialize(value))
+                assert(ok and math.type(out) == "float",
+                    ("expected %s to decode as a float"):format(tostring(value)))
+            end
+        end
+    end
+
 
     print("All tests passed!")
 end


### PR DESCRIPTION
## Summary

A set of correctness fixes for edge cases in the (de)serialization scheme, each with dedicated regression tests. Validated on **PUC Lua 5.1.4** (the WoW-matching runtime), **Lua 5.4**, and **LuaJIT 2.1**.

## Fixes (LibSerialize.lua)

- **Stable-sort crash** — `StableKeySort` now defines a total, crash-free ordering over all key types. Previously `stable = true` errored (`Unhandled sort type(s)`) whenever a map had two or more reference-type keys, or an incomparable mix such as `boolean + table`. Present since `stable` was introduced (v1.1.0).
- **Large integers (exact)** — whole numbers with magnitude > 2^53 (Lua 5.3+ integer subtype) now serialize as their exact decimal string via the existing `NUM_FLOATSTR` type, instead of overflowing the 56-bit integer encoding (which silently corrupted them, e.g. `2^56 - 1` -> `255`) or crashing on `math.mininteger`. Whole doubles with magnitude >= 2^56 fall back to the lossless 8-byte double encoding.
- **Subnormals** — denormal doubles are now encoded/decoded instead of being flushed to zero.
- **Negative zero** — preserved as a fixed 7-byte `"-0.0"` `NUM_FLOATSTR` rather than collapsing to `+0`.
- **Integer subtype (Lua 5.3+)** — embedded integers now decode back as integers (via `math_floor` of the exact division) instead of floats. Value-preserving no-op on Lua 5.1.
- **`__LibSerialize` guard** — a non-table metatable field is now ignored instead of being indexed (which errored).
- Minor: `IsSerializableType` no longer passes a spurious leading argument; removed dead locals in the async `SerializeEx` path.

## Tests (tests.lua)

- Regression tests for every fix above.
- The stable-order test is now robust to per-process hash-seed randomization (retries with capacity-spanning filler until a differing iteration order is observed).
- NaN **and** negative zero are compared in string form (`==` can't distinguish either case).
- Cross-version compatibility now runs against **v1.2.1**.

## Compatibility

- Large-integer and negative-zero encodings **reuse `NUM_FLOATSTR`**, so **older deserializers (v1.0.0-v1.2.1) decode the new output correctly** — no serialization-version bump.
- The subnormal encoding is the one exception: pre-fix versions misread new subnormal bytes. Negligible in practice, since old versions never emitted subnormals (they flushed to zero), so there is no legacy data to clash with.

## New file

- `archive/LibSerialize-v1-2-1.lua` — byte-exact snapshot of the released v1.2.1, added to the cross-version compat matrix.